### PR TITLE
Themes premium db migration

### DIFF
--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -58,7 +58,7 @@ module Admin
     end
 
     def theme_params
-      params.require(:theme).permit(:name, :active)
+      params.require(:theme).permit(:name, :active, :is_premium)
     end
   end
 end

--- a/app/views/admin/themes/edit.html.haml
+++ b/app/views/admin/themes/edit.html.haml
@@ -16,6 +16,12 @@
             %div.form-group.form-check
               = f.check_box :active, class: 'form-check-input'
               = f.label :active, 'Active', class: 'form-check-label'
+              %p.text-muted any user with a de-active theme will be switched to free default theme
+
+            %div.form-group.form-check
+              = f.check_box :is_premium, class: 'form-check-input'
+              = f.label :is_premium, 'Premium', class: 'form-check-label'
+              %p.text-muted Upgrades theme to a premium theme
 
         %div.card-footer
           = f.submit 'Update Theme', class: 'btn btn-primary'

--- a/app/views/admin/themes/index.html.haml
+++ b/app/views/admin/themes/index.html.haml
@@ -9,7 +9,7 @@
           %tr
             %th.text-white Name
             %th.text-white Active
-            %th.text-white Premium template
+            %th.text-white Pricing
             %th.text-white Usage
             %th.text-white edit
             %th.text-white delete
@@ -18,7 +18,7 @@
             %tr
               %td.text-white= theme.name
               %td.text-white= theme.active ? 'Yes' : 'No'
-              %td.text-white= theme.is_premium ? 'Yes' : 'No'
+              %td.text-white= theme.is_premium ? 'premium' : 'free'
               %td.text-white
                 =theme.download_count
               %td

--- a/app/views/admin/themes/index.html.haml
+++ b/app/views/admin/themes/index.html.haml
@@ -9,6 +9,7 @@
           %tr
             %th.text-white Name
             %th.text-white Active
+            %th.text-white Premium template
             %th.text-white Usage
             %th.text-white edit
             %th.text-white delete
@@ -17,6 +18,7 @@
             %tr
               %td.text-white= theme.name
               %td.text-white= theme.active ? 'Yes' : 'No'
+              %td.text-white= theme.is_premium ? 'Yes' : 'No'
               %td.text-white
                 =theme.download_count
               %td

--- a/db/migrate/20240707170713_add_is_premium_to_themes.rb
+++ b/db/migrate/20240707170713_add_is_premium_to_themes.rb
@@ -1,0 +1,5 @@
+class AddIsPremiumToThemes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :themes, :is_premium, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_06_191350) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_07_170713) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -136,6 +136,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_06_191350) do
     t.datetime "updated_at", null: false
     t.boolean "active", default: true
     t.integer "download_count", default: 0
+    t.boolean "is_premium", default: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Adds a `is_premium` column to the theme table. 

We can now allow or prevent users from selecting a theme based on their subscription status. 

Premium vs free themes can be controlled via the admin dashboard i.e it can be enabled disabled for each theme: 

![Screenshot 2024-07-07 at 6 13 02 PM](https://github.com/ashToronto/career_crafter_pro/assets/33923739/0899de0b-5775-45c3-87db-4e2d109b934e)

In your databse GUI under the theme table you should be able to see the `is_premium` column 

![Screenshot 2024-07-07 at 6 14 06 PM](https://github.com/ashToronto/career_crafter_pro/assets/33923739/0fff64d3-6ca2-4133-9d76-89212ac924a2)

To test changes locally run `rake db:migrate` to update your database schema and local psql instance. 
