### PR TITLE
Stripe subscriptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,9 @@ gem 'wkhtmltopdf-binary'
 gem 'friendly_id', '~> 5.4.0'
 gem 'figaro'
 
+gem "stripe", "~> 12.1"
+
+
 group :development, :test do
   gem "debug", platforms: %i[ mri mswin mswin64 mingw x64_mingw ]
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,6 +340,7 @@ GEM
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
+    stripe (12.1.0)
     temple (0.10.3)
     thor (1.3.0)
     tilt (2.3.0)
@@ -404,6 +405,7 @@ DEPENDENCIES
   simplecov
   sprockets-rails
   stimulus-rails
+  stripe (~> 12.1)
   turbo-rails
   tzinfo-data
   web-console

--- a/app/.rubocop.yml
+++ b/app/.rubocop.yml
@@ -1,4 +1,10 @@
 # .rubocop.yml
 Metrics/BlockLength:
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,0 +1,44 @@
+class SubscriptionsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    plan_id = params[:plan_id]
+    session = Stripe::Checkout::Session.create(
+      payment_method_types: ['card'],
+      line_items: [{
+        price: plan_id,
+        quantity: 1
+      }],
+      mode: 'subscription',
+      success_url: subscription_success_url + '?session_id={CHECKOUT_SESSION_ID}',
+      cancel_url: subscription_cancel_url
+    )
+
+    # renders the stripe checkout url for js to handle
+    render json: { checkout_url: session.url }
+    # redirect_to session.url, allow_other_host: true
+  end
+
+  def success
+    session_id = params[:session_id]
+    session = Stripe::Checkout::Session.retrieve(session_id)
+
+    customer = Stripe::Customer.retrieve(session.customer)
+    subscription = Stripe::Subscription.retrieve(session.subscription)
+
+    @user = current_user
+    @subscription_plan = SubscriptionPlan.find_by(stripe_plan_id: subscription.plan.id)
+
+    @user.subscriptions.create!(
+      stripe_subscription_id: subscription.id,
+      status: :active,
+      subscription_plan: @subscription_plan
+    )
+
+    redirect_to dashboard_path, notice: 'Subscription successful!'
+  end
+
+  def cancel
+    redirect_to pricing_path, alert: 'Subscription cancelled.'
+  end
+end

--- a/app/javascript/controllers/subscription_controller.js
+++ b/app/javascript/controllers/subscription_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "button" ]
+
+  createCheckoutSession(event) {
+    event.preventDefault()
+
+    const url = event.target.closest('form').action
+    const planId = event.target.dataset.planId
+
+    fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+      },
+      body: JSON.stringify({ plan_id: planId })
+    })
+    .then(response => response.json())
+    .then(data => {
+      window.location.href = data.checkout_url
+    })
+    .catch(error => {
+      console.error('Error:', error)
+    })
+  }
+}

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,0 +1,11 @@
+# app/models/subscription.rb
+class Subscription < ApplicationRecord
+  belongs_to :user
+  belongs_to :subscription_plan
+
+  enum status: { active: 0, canceled: 1 }
+
+  validates :stripe_subscription_id, presence: true, uniqueness: true
+  validates :status, presence: true
+  validates :subscription_plan, presence: true
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -8,4 +8,8 @@ class Subscription < ApplicationRecord
   validates :stripe_subscription_id, presence: true, uniqueness: true
   validates :status, presence: true
   validates :subscription_plan, presence: true
+
+  def active_or_in_grace_period?
+    active? || (canceled? && end_date.present? && end_date > Time.current)
+  end
 end

--- a/app/models/subscription_plan.rb
+++ b/app/models/subscription_plan.rb
@@ -1,0 +1,10 @@
+# app/models/subscription_plan.rb
+class SubscriptionPlan < ApplicationRecord
+  has_many :subscriptions
+
+  enum customer_type: { candidate: 0 }
+
+  validates :name, presence: true, uniqueness: true
+  validates :stripe_plan_id, presence: true, uniqueness: true
+  validates :customer_type, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,5 @@ class User < ApplicationRecord
   enum role: { candidate: 0, admin: 1 }
 
   has_many :resumes, dependent: :destroy
+  has_many :subscriptions, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,12 @@ class User < ApplicationRecord
 
   has_many :resumes, dependent: :destroy
   has_many :subscriptions, dependent: :destroy
+
+  def active_subscription?
+    subscriptions.any?(&:active_or_in_grace_period?)
+  end
+
+  def active_candidate_subscription?
+    active_subscription? && subscriptions.any? { |s| s.subscription_plan.customer_type == 'candidate' }
+  end
 end

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -9,11 +9,11 @@
         %li.nav-item.dropdown
           %a.nav-link.dropdown-toggle{"href" => "#", "id" => "navbarDropdownMenuLink", "role" => "button", "data-bs-toggle" => "dropdown", "aria-expanded" => "false"}
             %i.bi.bi-bell-fill.me-2
-            Notifications
+            Settings
           .dropdown-menu.dropdown-menu-end.dark-dropdown{"aria-labelledby" => "navbarDropdownMenuLink"}
             = link_to edit_user_registration_path, class: 'dropdown-item' do
               %i.bi.bi-gear-wide-connected.me-2
-              Profile Settings
+              Profile
             - if current_user.admin?
               = link_to admin_root_path, class: 'dropdown-item' do
                 %i.bi.bi-gear-fill.me-2
@@ -21,7 +21,7 @@
             - if current_user.subscriptions.present?
               = link_to manage_subscription_path, class: 'dropdown-item' do
                 %i.bi.bi-gear-fill.me-2
-                Manage Subscriptions
+                Subscriptions
             = form_tag destroy_user_session_path, method: :delete, class: 'dropdown-item' do
               = button_tag type: 'submit', class: 'btn btn-logout' do
                 %i.bi.bi-box-arrow-right.me-2

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -13,11 +13,15 @@
           .dropdown-menu.dropdown-menu-end.dark-dropdown{"aria-labelledby" => "navbarDropdownMenuLink"}
             = link_to edit_user_registration_path, class: 'dropdown-item' do
               %i.bi.bi-gear-wide-connected.me-2
-              Manage Account
+              Profile Settings
             - if current_user.admin?
               = link_to admin_root_path, class: 'dropdown-item' do
                 %i.bi.bi-gear-fill.me-2
-                Admin Settings
+                Admin Dashboard
+            - if current_user.subscriptions.present?
+              = link_to manage_subscription_path, class: 'dropdown-item' do
+                %i.bi.bi-gear-fill.me-2
+                Manage Subscriptions
             = form_tag destroy_user_session_path, method: :delete, class: 'dropdown-item' do
               = button_tag type: 'submit', class: 'btn btn-logout' do
                 %i.bi.bi-box-arrow-right.me-2

--- a/app/views/resumes/_sidebar.html.haml
+++ b/app/views/resumes/_sidebar.html.haml
@@ -7,6 +7,11 @@
   %div.row
     %nav#sidebarMenu.col-md.col-lg.d-md-block.sidebar.collapse
       .position-sticky.pt-3
+
+        - unless current_user.subscriptions.present?
+          %turbo-frame#subscription_frame
+            = button_to 'Upgrade to Premium', subscriptions_path, method: :post, class: 'btn btn-primary', data: { controller: "subscription", action: "click->subscription#createCheckoutSession", subscription_target: "button", plan_id: ENV['CANDIDATE_PLAN_ID'] }
+
         %ul.nav.flex-column
           %li.nav-item
             = link_to resume_path(@resume), class: 'nav-link' + (current_page?(resume_path(@resume)) ? ' active text' : ' text-white') do

--- a/app/views/resumes/_sidebar.html.haml
+++ b/app/views/resumes/_sidebar.html.haml
@@ -8,9 +8,14 @@
     %nav#sidebarMenu.col-md.col-lg.d-md-block.sidebar.collapse
       .position-sticky.pt-3
 
-        - unless current_user.subscriptions.present?
-          %turbo-frame#subscription_frame
-            = button_to 'Upgrade to Premium', subscriptions_path, method: :post, class: 'btn btn-primary', data: { controller: "subscription", action: "click->subscription#createCheckoutSession", subscription_target: "button", plan_id: ENV['CANDIDATE_PLAN_ID'] }
+        - # Subscription button is hidden in development mode
+        - if Rails.env.development?
+          - if current_user.active_candidate_subscription?
+            %turbo-frame#subscription_frame
+              %p.text-muted You have Premium Access
+          - else
+            %turbo-frame#subscription_frame
+              = button_to 'Upgrade to Premium', subscriptions_path, method: :post, class: 'btn btn-primary', data: { controller: "subscription", action: "click->subscription#createCheckoutSession", subscription_target: "button", plan_id: ENV['CANDIDATE_PLAN_ID'] }
 
         %ul.nav.flex-column
           %li.nav-item

--- a/app/views/subscriptions/manage.html.haml
+++ b/app/views/subscriptions/manage.html.haml
@@ -1,0 +1,25 @@
+%h1.text-center.p-4 Manage Subscription
+
+.container.text-center
+  - if @subscription.present?
+    %p
+      %strong Plan:
+      = @subscription.subscription_plan.name
+    %p
+      %strong Status:
+      = @subscription.status.capitalize
+    %p
+      %strong Start Date:
+      = @subscription.created_at.strftime("%B %d, %Y")
+    %p
+      %strong Next Billing Date:
+      = @next_billing_date.strftime("%B %d, %Y")
+
+    - if @subscription.active?
+      = button_to 'Cancel Subscription', cancel_subscription_path, method: :post, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to cancel your subscription?' }
+    - else
+      %p Your subscription is canceled.
+      %p.text-muted Continue using our premium features until your last billing date
+      %p.text-muted Re-activate your subscription by creating a new one after your final billing date
+  - else
+    %p You do not have an active subscription.

--- a/app/views/subscriptions/manage.html.haml
+++ b/app/views/subscriptions/manage.html.haml
@@ -17,9 +17,9 @@
 
     - if @subscription.active?
       = button_to 'Cancel Subscription', cancel_subscription_path, method: :post, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to cancel your subscription?' }
-    - else
+    - elsif @subscription.canceled? && @subscription.end_date > Time.current
       %p Your subscription is canceled.
-      %p.text-muted Continue using our premium features until your last billing date
+      %p.text-muted Continue using our premium features until your last billing date: #{@subscription.end_date.strftime("%B %d, %Y")}
       %p.text-muted Re-activate your subscription by creating a new one after your final billing date
   - else
     %p You do not have an active subscription.

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,0 +1,1 @@
+Stripe.api_key = ENV['STRIPE_SECRET_KEY']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,4 +33,6 @@ Rails.application.routes.draw do
   resources :subscriptions, only: [:create]
   get 'subscription_success', to: 'subscriptions#success'
   get 'subscription_cancel', to: 'subscriptions#cancel'
+  get 'manage_subscription', to: 'subscriptions#manage'
+  post 'cancel_subscription', to: 'subscriptions#cancel'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,4 +29,8 @@ Rails.application.routes.draw do
       get 'download_pdf'
     end
   end
+
+  resources :subscriptions, only: [:create]
+  get 'subscription_success', to: 'subscriptions#success'
+  get 'subscription_cancel', to: 'subscriptions#cancel'
 end

--- a/db/migrate/20240709034328_create_subscription_plans.rb
+++ b/db/migrate/20240709034328_create_subscription_plans.rb
@@ -1,0 +1,12 @@
+class CreateSubscriptionPlans < ActiveRecord::Migration[7.1]
+  def change
+    create_table :subscription_plans do |t|
+      t.string :name, null: false
+      t.string :stripe_plan_id, null: false
+      t.integer :customer_type, null: false
+
+      t.timestamps
+    end
+    add_index :subscription_plans, :stripe_plan_id, unique: true
+  end
+end

--- a/db/migrate/20240709035236_create_subscriptions.rb
+++ b/db/migrate/20240709035236_create_subscriptions.rb
@@ -1,0 +1,13 @@
+class CreateSubscriptions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :subscriptions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :subscription_plan, null: false, foreign_key: true
+      t.string :stripe_subscription_id
+      t.integer :status
+
+      t.timestamps
+    end
+    add_index :subscriptions, :stripe_subscription_id, unique: true
+  end
+end

--- a/db/migrate/20240711165539_add_end_date_to_subscriptions.rb
+++ b/db/migrate/20240711165539_add_end_date_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddEndDateToSubscriptions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :subscriptions, :end_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_07_170713) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_09_035236) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -130,6 +130,27 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_07_170713) do
     t.index ["resume_id"], name: "index_social_links_on_resume_id"
   end
 
+  create_table "subscription_plans", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "stripe_plan_id", null: false
+    t.integer "customer_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["stripe_plan_id"], name: "index_subscription_plans_on_stripe_plan_id", unique: true
+  end
+
+  create_table "subscriptions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "subscription_plan_id", null: false
+    t.string "stripe_subscription_id"
+    t.integer "status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["stripe_subscription_id"], name: "index_subscriptions_on_stripe_subscription_id", unique: true
+    t.index ["subscription_plan_id"], name: "index_subscriptions_on_subscription_plan_id"
+    t.index ["user_id"], name: "index_subscriptions_on_user_id"
+  end
+
   create_table "themes", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -168,4 +189,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_07_170713) do
   add_foreign_key "resumes", "users"
   add_foreign_key "skills", "resumes"
   add_foreign_key "social_links", "resumes"
+  add_foreign_key "subscriptions", "subscription_plans"
+  add_foreign_key "subscriptions", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_09_035236) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_11_165539) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -146,6 +146,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_09_035236) do
     t.integer "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "end_date"
     t.index ["stripe_subscription_id"], name: "index_subscriptions_on_stripe_subscription_id", unique: true
     t.index ["subscription_plan_id"], name: "index_subscriptions_on_subscription_plan_id"
     t.index ["user_id"], name: "index_subscriptions_on_user_id"

--- a/env.example
+++ b/env.example
@@ -19,3 +19,9 @@ test:
 ADMIN_EMAIL: "my-mock-email@example.com"
 POSTGRES_USER: "my local postgres role"
 POSTGRES_PASSWORD: "my local postgres password"
+
+# Stripe payments
+STRIPE_SECRET_KEY: your_stripe_secret_key
+STRIPE_PUBLISHABLE_KEY: your_stripe_publishable_key
+STRIPE_WEBHOOK_SECRET: your_stripe_webhook_secret
+CANDIDATE_PLAN_ID: price_1KqYAbXXX... # Replace with your actual Stripe price ID

--- a/lib/tasks/stripe_subscription_plans.rake
+++ b/lib/tasks/stripe_subscription_plans.rake
@@ -1,0 +1,16 @@
+# lib/tasks/stripe_subscription_plans.rake
+namespace :stripe do
+  desc 'Create subscription plans in the database'
+  task create_plans: :environment do
+    plans = [
+      { name: 'Candidate Premium', stripe_plan_id: ENV['CANDIDATE_PLAN_ID'], customer_type: :candidate }
+      # Add more plans here as needed
+    ]
+
+    plans.each do |plan_attrs|
+      plan = SubscriptionPlan.find_or_initialize_by(stripe_plan_id: plan_attrs[:stripe_plan_id])
+      plan.update!(plan_attrs)
+      puts "Created or updated subscription plan: #{plan.name}"
+    end
+  end
+end

--- a/spec/factories/subscription_plans.rb
+++ b/spec/factories/subscription_plans.rb
@@ -1,0 +1,8 @@
+# spec/factories/subscription_plans.rb
+FactoryBot.define do
+  factory :subscription_plan do
+    name { 'Basic Plan' }
+    stripe_plan_id { "price_#{SecureRandom.hex(6)}" }
+    customer_type { :candidate }
+  end
+end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     subscription_plan
     stripe_subscription_id { "sub_#{SecureRandom.hex(8)}" }
     status { :active }
+    end_date { nil }
   end
 end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -1,0 +1,9 @@
+# spec/factories/subscriptions.rb
+FactoryBot.define do
+  factory :subscription do
+    user
+    subscription_plan
+    stripe_subscription_id { "sub_#{SecureRandom.hex(8)}" }
+    status { :active }
+  end
+end

--- a/spec/models/subscription_plan_spec.rb
+++ b/spec/models/subscription_plan_spec.rb
@@ -1,0 +1,38 @@
+# spec/models/subscription_plan_spec.rb
+require 'rails_helper'
+
+RSpec.describe SubscriptionPlan, type: :model do
+  it { should have_many(:subscriptions) }
+
+  it { should define_enum_for(:customer_type).with_values(candidate: 0) }
+
+  it 'is valid with valid attributes' do
+    subscription_plan = build(:subscription_plan)
+    expect(subscription_plan).to be_valid
+  end
+
+  it 'is not valid without a name' do
+    subscription_plan = build(:subscription_plan, name: nil)
+    expect(subscription_plan).not_to be_valid
+    expect(subscription_plan.errors.messages[:name]).to include("can't be blank")
+  end
+
+  it 'is not valid without a stripe_plan_id' do
+    subscription_plan = build(:subscription_plan, stripe_plan_id: nil)
+    expect(subscription_plan).not_to be_valid
+    expect(subscription_plan.errors.messages[:stripe_plan_id]).to include("can't be blank")
+  end
+
+  it 'is not valid without a customer_type' do
+    subscription_plan = build(:subscription_plan, customer_type: nil)
+    expect(subscription_plan).not_to be_valid
+    expect(subscription_plan.errors.messages[:customer_type]).to include("can't be blank")
+  end
+
+  it 'is not valid with a duplicate stripe_plan_id' do
+    create(:subscription_plan, stripe_plan_id: 'duplicate_id')
+    subscription_plan = build(:subscription_plan, stripe_plan_id: 'duplicate_id')
+    expect(subscription_plan).not_to be_valid
+    expect(subscription_plan.errors.messages[:stripe_plan_id]).to include('has already been taken')
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,4 +1,3 @@
-# spec/models/subscription_spec.rb
 require 'rails_helper'
 
 RSpec.describe Subscription, type: :model do
@@ -29,5 +28,42 @@ RSpec.describe Subscription, type: :model do
     subscription = build(:subscription, stripe_subscription_id: 'duplicate_id')
     expect(subscription).not_to be_valid
     expect(subscription.errors.messages[:stripe_subscription_id]).to include('has already been taken')
+  end
+
+  describe '#active_or_in_grace_period?' do
+    let(:subscription) { create(:subscription, status: :canceled, end_date: end_date) }
+
+    context 'when the subscription is active' do
+      let(:end_date) { nil }
+
+      it 'returns true' do
+        subscription.update(status: :active)
+        expect(subscription.active_or_in_grace_period?).to be(true)
+      end
+    end
+
+    context 'when the subscription is canceled and within the grace period' do
+      let(:end_date) { 2.days.from_now }
+
+      it 'returns true' do
+        expect(subscription.active_or_in_grace_period?).to be(true)
+      end
+    end
+
+    context 'when the subscription is canceled and the grace period has ended' do
+      let(:end_date) { 2.days.ago }
+
+      it 'returns false' do
+        expect(subscription.active_or_in_grace_period?).to be(false)
+      end
+    end
+
+    context 'when the subscription is canceled and no end date is present' do
+      let(:end_date) { nil }
+
+      it 'returns false' do
+        expect(subscription.active_or_in_grace_period?).to be(false)
+      end
+    end
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,0 +1,33 @@
+# spec/models/subscription_spec.rb
+require 'rails_helper'
+
+RSpec.describe Subscription, type: :model do
+  it { should belong_to(:user) }
+  it { should belong_to(:subscription_plan) }
+
+  it { should define_enum_for(:status).with_values(active: 0, canceled: 1) }
+
+  it 'is valid with valid attributes' do
+    subscription = build(:subscription)
+    expect(subscription).to be_valid
+  end
+
+  it 'is not valid without a stripe_subscription_id' do
+    subscription = build(:subscription, stripe_subscription_id: nil)
+    expect(subscription).not_to be_valid
+    expect(subscription.errors.messages[:stripe_subscription_id]).to include("can't be blank")
+  end
+
+  it 'is not valid without a status' do
+    subscription = build(:subscription, status: nil)
+    expect(subscription).not_to be_valid
+    expect(subscription.errors.messages[:status]).to include("can't be blank")
+  end
+
+  it 'is not valid with a duplicate stripe_subscription_id' do
+    create(:subscription, stripe_subscription_id: 'duplicate_id')
+    subscription = build(:subscription, stripe_subscription_id: 'duplicate_id')
+    expect(subscription).not_to be_valid
+    expect(subscription.errors.messages[:stripe_subscription_id]).to include('has already been taken')
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  context 'Resumes' do
+    it { should have_many(:resumes) }
+  end
+
   # Happy path tests
 
   it 'is a candidate by default' do
@@ -76,7 +80,16 @@ RSpec.describe User, type: :model do
     end
   end
 
-  context 'Resumes' do
-    it { should have_many(:resumes) }
+  # Testing subscriptions
+  context 'with subscriptions' do
+    it { should have_many(:subscriptions) }
+
+    it 'can have subscriptions' do
+      user = create(:user)
+      subscription_plan = create(:subscription_plan)
+      subscription = create(:subscription, user: user, subscription_plan: subscription_plan)
+
+      expect(user.subscriptions).to include(subscription)
+    end
   end
 end


### PR DESCRIPTION
#41 

This feature incorporates a set of new tables/apis that connect to stripe. It is built to scale with possibility of multiple subscription types i.e candidates vs employers. It is currently only accessible in development mode and will be unlocked when we are ready to release on production (the .com domain). 

The stripe gem was added and configured also.
Added a whole bunch of unit tests for stability.  

**For the team to integrate these changes in your local environments** 
-> Once this pr is merged to main do a `git pull` in your main branch 
-> Run `bundle install` to setup the stripe gem 
-> Run `rake db:migrate` to update your local postgres db with the newly updated schema. 
-> Ping me for the stripe api keys also and update your `application.yml` file reference the new changes in `env.example`

**How Stripe works.integrates:** 

The actual product and subscription and price is stored on the stripe dashboard. We get access to api keys that reference it. When a user clicks the upgrade button they are redirected to a checkout page powered by stripe (3rd party) with a unique customer session. Stripe accepts multiple payment types. When the users subscription is successful it redirects back to the application and creates a new entry in the subscriptions table with a customer id and a subscription plan id which reference the product and price in the stripe dashboard. 

In production we will only start accepting payments once we have a decent number of service offerings, until then this feature will remain a development only feature locked behind a feature flag. 

**Feature changes**

When you don't have an active subscription - the checkout/upgrade button shows but only in development mode (hidden in production  until release):

![Screenshot 2024-07-14 at 12 02 28 AM](https://github.com/user-attachments/assets/b4425e21-f6a4-43a4-9c43-1e39f5f7fb97)

stripe checkout: 

![Screenshot 2024-07-14 at 12 03 20 AM](https://github.com/user-attachments/assets/689cc857-592b-4027-98b7-6e8c3f10c6af)

cancelled and active subscriptions in new interface for user/candidate subscription management dashboard: 

Active: 
![Screenshot 2024-07-14 at 12 05 14 AM](https://github.com/user-attachments/assets/76616db8-43bf-4d25-adf9-1b6633fcee45)

Cancelled: 
![Screenshot 2024-07-14 at 12 01 22 AM](https://github.com/user-attachments/assets/de080a88-7ef7-4706-8e76-af5a62b40965)


New settings tab option to manage active/cancelled subscriptions:
![Screenshot 2024-07-14 at 12 00 16 AM](https://github.com/user-attachments/assets/875e2369-59dd-499d-bbfb-6c1d17ba2c10)


When you have premium access and have an active subscription: 

![Screenshot 2024-07-13 at 11 58 14 PM](https://github.com/user-attachments/assets/69c210e1-0c71-47bb-a3dd-da1e30b5509d)
