### PR TITLE
#118 update resume show page, add accordian view to replace card view

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -2,6 +2,9 @@
 
 import { application } from "controllers/application"
 
+import SpinnerController from "./spinner_controller"
+application.register("spinner", SpinnerController)
+
 // Eager load all controllers defined in the import map under controllers/**/*_controller
 import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
 eagerLoadControllersFrom("controllers", application)

--- a/app/javascript/controllers/spinner_controller.js
+++ b/app/javascript/controllers/spinner_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["spinner"]
+
+  connect() {
+    // console.log("SpinnerController connected")
+    if (this.hasSpinnerTarget) {
+      console.log("Spinner target found")
+      this.showSpinner()
+    } else {
+      console.error("Missing spinner target")
+    }
+  }
+
+  showSpinner() {
+    // console.log("Show spinner")
+    this.spinnerTarget.style.display = "block"
+    setTimeout(() => {
+      this.hideSpinner()
+    }, 5136) // 5 milliseconds delay
+  }
+
+  hideSpinner() {
+    // console.log("Hide spinner")
+    this.spinnerTarget.style.display = "none"
+    this.iframeTarget.style.visibility = "visible"
+  }
+}

--- a/app/views/resumes/show.html.haml
+++ b/app/views/resumes/show.html.haml
@@ -70,7 +70,10 @@
                 .accordion-body.bg-dark.text-white
                   = render 'resumes/sections/social_links', resume: @resume
 
-        .theme-editor-container.position-relative
-          %h3.pt-4 PDF Preview
-          - if @resume.theme
-            %iframe{ src: resume_path(@resume, format: :pdf), width: "100%", height: "1000px", style: "border: none;" }
+          .theme-editor-container.position-relative
+            %h3.pt-4 PDF Preview
+            - if @resume.theme
+              .spinner-container.d-flex.justify-content-center.align-items-center
+                .spinner-border.text-danger.spinner-border-lg{ role: "status", data: { controller: "spinner", spinner_target: "spinner" } }
+                  %span.visually-hidden Loading...
+              %iframe{ src: resume_path(@resume, format: :pdf), width: "100%", height: "1000px", style: "border: none;", data: { spinner_target: "iframe" } }

--- a/app/views/resumes/show.html.haml
+++ b/app/views/resumes/show.html.haml
@@ -25,23 +25,14 @@
               .accordion-body.bg-dark.text-white
                 = render 'resumes/sections/personal_details', resume: @resume
 
-          - if @resume.cover_letter.present?
+          - if @resume.experiences.any?
             .accordion-item
               .accordion-header
-                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseCoverLetter" }, aria_expanded: "true", aria_controls: "collapseCoverLetter" }
-                  Edit Cover Letter
-              .accordion-collapse.collapse#collapseCoverLetter{ aria_labelledby: "headingCoverLetter", data: { bs_parent: "#resumeAccordion" } }
+                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseWorkExperience" }, aria_expanded: "true", aria_controls: "collapseWorkExperience" }
+                  Edit Work Experience
+              .accordion-collapse.collapse#collapseWorkExperience{ aria_labelledby: "headingWorkExperience", data: { bs_parent: "#resumeAccordion" } }
                 .accordion-body.bg-dark.text-white
-                  = render 'resumes/sections/cover_letter', resume: @resume
-
-          - if @resume.skills.any?
-            .accordion-item
-              .accordion-header
-                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseSkills" }, aria_expanded: "true", aria_controls: "collapseSkills" }
-                  Edit Skills
-              .accordion-collapse.collapse#collapseSkills{ aria_labelledby: "headingSkills", data: { bs_parent: "#resumeAccordion" } }
-                .accordion-body.bg-dark.text-white
-                  = render 'resumes/sections/skills', resume: @resume
+                  = render 'resumes/sections/experiences', resume: @resume
 
           - if @resume.educations.any?
             .accordion-item
@@ -52,14 +43,14 @@
                 .accordion-body.bg-dark.text-white
                   = render 'resumes/sections/educations', resume: @resume
 
-          - if @resume.experiences.any?
+          - if @resume.skills.any?
             .accordion-item
               .accordion-header
-                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseWorkExperience" }, aria_expanded: "true", aria_controls: "collapseWorkExperience" }
-                  Edit Work Experience
-              .accordion-collapse.collapse#collapseWorkExperience{ aria_labelledby: "headingWorkExperience", data: { bs_parent: "#resumeAccordion" } }
+                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseSkills" }, aria_expanded: "true", aria_controls: "collapseSkills" }
+                  Edit Skills
+              .accordion-collapse.collapse#collapseSkills{ aria_labelledby: "headingSkills", data: { bs_parent: "#resumeAccordion" } }
                 .accordion-body.bg-dark.text-white
-                  = render 'resumes/sections/experiences', resume: @resume
+                  = render 'resumes/sections/skills', resume: @resume
 
           - if @resume.social_link.present?
             .accordion-item
@@ -69,6 +60,15 @@
               .accordion-collapse.collapse#collapseSocialLinks{ aria_labelledby: "headingSocialLinks", data: { bs_parent: "#resumeAccordion" } }
                 .accordion-body.bg-dark.text-white
                   = render 'resumes/sections/social_links', resume: @resume
+
+          - if @resume.cover_letter.present?
+            .accordion-item
+              .accordion-header
+                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseCoverLetter" }, aria_expanded: "true", aria_controls: "collapseCoverLetter" }
+                  Edit Summary
+              .accordion-collapse.collapse#collapseCoverLetter{ aria_labelledby: "headingCoverLetter", data: { bs_parent: "#resumeAccordion" } }
+                .accordion-body.bg-dark.text-white
+                  = render 'resumes/sections/cover_letter', resume: @resume
 
           .theme-editor-container.position-relative
             %h3.pt-4 PDF Preview

--- a/app/views/resumes/show.html.haml
+++ b/app/views/resumes/show.html.haml
@@ -11,36 +11,66 @@
             Back
 
           - if @resume.theme
-            = link_to resume_path(@resume, format: :pdf), target: '_blank', class: 'btn' do
-              %i.bi.bi-eye-fill.me-1
-              Preview
             = link_to download_pdf_resume_path(@resume, format: :pdf), class: 'btn' do
               %i.bi.bi-download.me-1
               Download PDF
 
-      .container
-        = render 'resumes/sections/personal_details', resume: @resume
+      .container.pt-4
+        .accordion#resumeAccordion
+          .accordion-item
+            .accordion-header
+              %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapsePersonalDetails" }, aria_expanded: "true", aria_controls: "collapsePersonalDetails" }
+                Edit Personal Details
+            .accordion-collapse.collapse#collapsePersonalDetails{ aria_labelledby: "headingPersonalDetails", data: { bs_parent: "#resumeAccordion" } }
+              .accordion-body.bg-dark.text-white
+                = render 'resumes/sections/personal_details', resume: @resume
 
-        - if @resume.cover_letter.present?
-          = render 'resumes/sections/cover_letter', resume: @resume
+          - if @resume.cover_letter.present?
+            .accordion-item
+              .accordion-header
+                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseCoverLetter" }, aria_expanded: "true", aria_controls: "collapseCoverLetter" }
+                  Edit Cover Letter
+              .accordion-collapse.collapse#collapseCoverLetter{ aria_labelledby: "headingCoverLetter", data: { bs_parent: "#resumeAccordion" } }
+                .accordion-body.bg-dark.text-white
+                  = render 'resumes/sections/cover_letter', resume: @resume
 
-        - if @resume.skills.any?
-          %h3.mb-3 Skill Sets
-          = render 'resumes/sections/skills', resume: @resume
+          - if @resume.skills.any?
+            .accordion-item
+              .accordion-header
+                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseSkills" }, aria_expanded: "true", aria_controls: "collapseSkills" }
+                  Edit Skills
+              .accordion-collapse.collapse#collapseSkills{ aria_labelledby: "headingSkills", data: { bs_parent: "#resumeAccordion" } }
+                .accordion-body.bg-dark.text-white
+                  = render 'resumes/sections/skills', resume: @resume
 
-        %h3.pt-4 Quick Preview
-        .theme-editor.bg-light.rounded-3.d-none.d-md-block
+          - if @resume.educations.any?
+            .accordion-item
+              .accordion-header
+                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseEducation" }, aria_expanded: "true", aria_controls: "collapseEducation" }
+                  Edit Education
+              .accordion-collapse.collapse#collapseEducation{ aria_labelledby: "headingEducation", data: { bs_parent: "#resumeAccordion" } }
+                .accordion-body.bg-dark.text-white
+                  = render 'resumes/sections/educations', resume: @resume
+
+          - if @resume.experiences.any?
+            .accordion-item
+              .accordion-header
+                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseWorkExperience" }, aria_expanded: "true", aria_controls: "collapseWorkExperience" }
+                  Edit Work Experience
+              .accordion-collapse.collapse#collapseWorkExperience{ aria_labelledby: "headingWorkExperience", data: { bs_parent: "#resumeAccordion" } }
+                .accordion-body.bg-dark.text-white
+                  = render 'resumes/sections/experiences', resume: @resume
+
+          - if @resume.social_link.present?
+            .accordion-item
+              .accordion-header
+                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseSocialLinks" }, aria_expanded: "true", aria_controls: "collapseSocialLinks" }
+                  Edit Social Links
+              .accordion-collapse.collapse#collapseSocialLinks{ aria_labelledby: "headingSocialLinks", data: { bs_parent: "#resumeAccordion" } }
+                .accordion-body.bg-dark.text-white
+                  = render 'resumes/sections/social_links', resume: @resume
+
+        .theme-editor-container.position-relative
+          %h3.pt-4 PDF Preview
           - if @resume.theme
             %iframe{ src: resume_path(@resume, format: :pdf), width: "100%", height: "1000px", style: "border: none;" }
-
-        - if @resume.social_link.present?
-          = render 'resumes/sections/social_links', resume: @resume
-
-        - if @resume.educations.any?
-          %h3.mb-3 Education
-          = render 'resumes/sections/educations', resume: @resume
-
-        - if @resume.experiences.any?
-          .col-md-12
-            %h3.mb-3 Work Experience
-            = render 'resumes/sections/experiences', resume: @resume


### PR DESCRIPTION
#119 
Updated resume show page to have an accordian view. This replaces the rendered cards and compliments the spacing taken up by the iframe: 

I also got rid of the preview button as the iframe does that same functionality on page render. 

We can further improve this layout in the future. it's meant to improve readability. 

#114
Add loading spinner alos - it stops loading when the iframe is fully loaded/rendered. Uses bootstrap spinner.  

![Screenshot 2024-07-18 at 1 41 40 PM](https://github.com/user-attachments/assets/12767a92-a8fd-4185-b1a0-f01b8d72caa6)