### PR TITLE
#122 leverage eager loading only for spinner controller js remove imp…

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -2,9 +2,6 @@
 
 import { application } from "controllers/application"
 
-import SpinnerController from "./spinner_controller"
-application.register("spinner", SpinnerController)
-
 // Eager load all controllers defined in the import map under controllers/**/*_controller
 import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
 eagerLoadControllersFrom("controllers", application)


### PR DESCRIPTION
#122 there was a bug that appeared in production but worked fine in local - the spinner for resume show page. the spinner controller js wasn't working i.e infinite loading. this ticket fixes that - cause imporitng the spinner controller explicitly in index.js while we were also using eager loading - this is root cause of the error. 

it showed a 404 on console linking to spinner_controller.js 404 error.