### PR TITLE
User session cookies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "jbuilder"
 # gem "bcrypt", "~> 3.1.7"
 
 gem 'devise'
+gem 'activerecord-session_store'
 gem 'aws-sdk-ses', '~> 1'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,13 @@ GEM
       activemodel (= 7.1.2)
       activesupport (= 7.1.2)
       timeout (>= 0.4.0)
+    activerecord-session_store (2.1.0)
+      actionpack (>= 6.1)
+      activerecord (>= 6.1)
+      cgi (>= 0.3.6)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 4)
+      railties (>= 6.1)
     activestorage (7.1.2)
       actionpack (= 7.1.2)
       activejob (= 7.1.2)
@@ -109,6 +116,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.4.1)
     childprocess (5.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
@@ -197,6 +205,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.21.1)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mutex_m (0.2.0)
     net-imap (0.4.9.1)
       date
@@ -377,6 +386,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-session_store
   aws-sdk-ses (~> 1)
   bootsnap
   bullet

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ CareerCrafterPro is a web application that allows users to create, customize, an
 #### Setting up Ruby 3.0.0
 
 ##### Windows OS
+
 1. Install Ruby 3.0.0 from Ruby Installer
 2. Git clone asdf repo to access asdf: git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.14.0
 3. Install wsl on machine: wsl --install
@@ -28,6 +29,7 @@ CareerCrafterPro is a web application that allows users to create, customize, an
 10. asdf install ruby 3.0.0
 
 ##### Mac OS
+
 1. Have Homebrew installed. If you don't already have it installed, download it here: https://brew.sh/
 2. Install GPG (Gnu Privacy Guard). To install, run `brew install gpg` in your local terminal.
 3. Install RVM (Ruby Version Manager)
@@ -45,24 +47,29 @@ CareerCrafterPro is a web application that allows users to create, customize, an
 #### Setting up Rails 7.1.2.0
 
 ##### Windows OS
+
 **In the directory in WSL that ruby was installed**
+
 1. sudo apt-get install build-essential libssl-dev libreadline-dev zlib1g-dev libsqlite3-dev
 2. the current version of ruby is not 3.0.0, so run: asdf install ruby 3.0.0
 3. ensure that the global version of ruby on your machine is the same run: asdf global ruby [my ruby version]
-4. ensure that the global version of ruby on the current  is the same run: asdf local ruby [my ruby version]
+4. ensure that the global version of ruby on the current is the same run: asdf local ruby [my ruby version]
 5. put the correct version of ruby into environment variables: export PATH="$HOME/.asdf/shims:$PATH"
 6. Install rails: Gem install rails
 
 #### Mac OS
+
 1. Run this command in the terminal to install Rails 7.1.2.0: `gem install rails -v 7.1.2`
 2. To make sure Rails is installed correctly, run: `rails -v`. It should output version 7.1.2.
 
 #### Setting up Postgres
 
 ##### Windows OS
+
 1. [Download and Install Postgres] (https://www.postgresql.org/download/windows/)
 2. sudo apt list --installed | grep postgresql
 3. sudo apt install postgresql-client
+
 4) sudo apt update
 5) sudo apt install postgresql postgresql-contrib
 6) sudo service postgresql status
@@ -70,6 +77,7 @@ CareerCrafterPro is a web application that allows users to create, customize, an
 8) sudo systemctl start postgresql
 
 #### Mac OS
+
 1. Install Postgres through Homebrew by running into terminal: `brew install postgresql`
 2. To verify the installation by connecting to the PostgreSQL server, run: `psql postgres`. To quit, run `\q` into the shell.
 3. When inside the shell, run command `CREATE ROLE myappuserName WITH LOGIN PASSWORD 'myapppassword';` to set up a pgsql role with priviledges.
@@ -77,23 +85,27 @@ CareerCrafterPro is a web application that allows users to create, customize, an
 #### Setting up Development Environment
 
 ##### Windows OS
+
 1. Clone the repository to your local machine linux environment.
 2. install the necessary yaml libraries: sudo apt-get update
-sudo apt-get install -y libyaml-dev
+   sudo apt-get install -y libyaml-dev
 3. sudo apt-get update
-sudo apt-get install -y libpq-dev
+   sudo apt-get install -y libpq-dev
 4. gem install pg -v '1.5.4'
 5. Run `bundle install` to install the project dependencies.
 6. Create an `application.yml` file in the `config` directory to store database login credentials(Use the `.env.example` file as a reference to set up necessary environment variables for your development environment.)
 
 #### Mac OS
+
 1. Clone the repository to your local working environment.
 2. Create an `application.yml` file in the `config` directory.
    - In this file, add these 2 lines to add our 2 key values, which represent our environment variables:
+
 ```
 POSTGRES_USER: myappuserName
 POSTGRES_PASSWORD: myapppassword
 ```
+
 3. Run `bundle install` to download project dependencies.
 
 ### Database Initialization
@@ -154,6 +166,24 @@ To add new templates and themes:
 - Store CSS for the new themes in `app/assets/stylesheets/themes/[my_pdf_design_name.css]`.
 - Add the theme name to the precompile list in `config/initializers/assets.rb` to ensure it loads correctly with Wicked PDF.
 - Update the database to include the new theme name corresponding to the new `.pdf.haml` file via admin dashboard or rake task in `create_theme_names.rake`.
+
+## Session Management
+
+### Purpose
+
+The application uses ActiveRecord's session store to manage user sessions. Each session is stored in the `sessions` table in the database. This table helps in tracking user sessions, maintaining login states, and providing necessary security features like CSRF protection.
+
+### Manual Cleanup of Sessions
+
+Due to the current limitations (absence of Redis or queuing services), the cleanup of old sessions is performed manually using a rake task. This manual cleanup is essential to ensure that the `sessions` table does not grow indefinitely, which could impact the performance of the application.
+
+#### Running the Cleanup Task
+
+To manually clean up old sessions, you can run the following rake task:
+
+```sh
+rake session:cleanup
+```
 
 ## Questions or Contributions
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -174,7 +174,7 @@ Devise.setup do |config|
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.
-  # config.rememberable_options = {}
+  config.rememberable_options = { expire_after: 2.weeks }
 
   # ==> Configuration for :validatable
   # Range for password length.

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :active_record_store, key: '_career_crafter_pro_session'

--- a/db/migrate/20240801011706_add_sessions_table.rb
+++ b/db/migrate/20240801011706_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[7.1]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_11_165539) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_01_011706) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -106,6 +106,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_11_165539) do
     t.index ["slug"], name: "index_resumes_on_slug", unique: true
     t.index ["theme_id"], name: "index_resumes_on_theme_id"
     t.index ["user_id"], name: "index_resumes_on_user_id"
+  end
+
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
   create_table "skills", force: :cascade do |t|

--- a/lib/tasks/session_cleanup.rake
+++ b/lib/tasks/session_cleanup.rake
@@ -1,0 +1,8 @@
+# rake session:cleanup
+namespace :session do
+  desc 'Clean up old sessions'
+  task cleanup: :environment do
+    ActiveRecord::SessionStore::Session.where('updated_at < ?', 2.weeks.ago).delete_all
+    puts 'Old sessions cleaned up'
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,8 @@ RSpec.configure do |config|
   config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
   config.use_transactional_fixtures = true
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
+
   # config.use_active_record = false # Uncomment this line if you're not using ActiveRecord
 
   # factory bot

--- a/spec/requests/user_sessions.rb
+++ b/spec/requests/user_sessions.rb
@@ -1,0 +1,69 @@
+# spec/requests/user_sessions_spec.rb
+
+require 'rails_helper'
+
+RSpec.describe 'UserSessions', type: :request do
+  let(:user) { create(:user, confirmed_at: Time.now) }
+
+  describe 'User login, signup, and logout' do
+    context 'when a user signs up' do
+      it 'creates a new user and session' do
+        expect do
+          post user_registration_path,
+               params: { user: { email: 'newuser@example.com', password: 'password',
+                                 password_confirmation: 'password' } }
+        end.to change(User, :count).by(1) # Ensure a new user is created
+                                   .and change {
+                                          ActiveRecord::SessionStore::Session.count
+                                        }.by(1) # Ensure a new session is created
+      end
+    end
+
+    context 'when a user logs in' do
+      before do
+        # Register a new user and confirm their email
+        post user_registration_path,
+             params: { user: { email: 'newuser@example.com', password: 'password',
+                               password_confirmation: 'password' } }
+        user = User.find_by(email: 'newuser@example.com')
+        user.update!(confirmed_at: Time.now) # Simulate email confirmation
+        sign_out :user
+      end
+
+      it 'updates the session data without creating a duplicate session' do
+        old_session_id = ActiveRecord::SessionStore::Session.last&.session_id
+
+        expect do
+          post user_session_path,
+               params: { user: { email: 'newuser@example.com', password: 'password' } }
+        end.not_to(change { ActiveRecord::SessionStore::Session.count }) # Ensure no new session is created
+
+        new_session_id = ActiveRecord::SessionStore::Session.last&.session_id
+        session_data = ActiveRecord::SessionStore::Session.last&.data
+
+        expect(new_session_id).not_to eq(old_session_id) # Ensure the session ID is updated
+        expect(session_data).to include('warden.user.user.key') # Ensure the session data includes the user key
+      end
+    end
+
+    context 'when a user logs out' do
+      before do
+        sign_in user
+      end
+
+      it 'updates the session data or creates a new session without including the user key' do
+        old_session_id = ActiveRecord::SessionStore::Session.last&.session_id
+
+        expect do
+          delete destroy_user_session_path
+        end.to(change { ActiveRecord::SessionStore::Session.count }) # Allow for the session count to change
+
+        new_session_id = ActiveRecord::SessionStore::Session.last&.session_id
+        session_data = ActiveRecord::SessionStore::Session.last&.data
+
+        expect(new_session_id).not_to eq(old_session_id) # Ensure the session ID is updated
+        expect(session_data).not_to include('warden.user.user.key') # Ensure the session data no longer includes the user key
+      end
+    end
+  end
+end

--- a/spec/tasks/session_cleanup_spec.rb
+++ b/spec/tasks/session_cleanup_spec.rb
@@ -1,0 +1,31 @@
+# spec/tasks/session_cleanup_spec.rb
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'session:cleanup', type: :task do
+  before :all do
+    Rake.application.load_rakefile
+    ActiveRecord::SessionStore::Session.delete_all
+  end
+
+  let(:task) { Rake::Task['session:cleanup'] }
+
+  it 'deletes sessions that have not been updated in the last two weeks' do
+    # Create sessions to test the cleanup
+    old_session = ActiveRecord::SessionStore::Session.create!(
+      session_id: 'old_session',
+      data: {},
+      updated_at: 3.weeks.ago
+    )
+    new_session = ActiveRecord::SessionStore::Session.create!(
+      session_id: 'new_session',
+      data: {},
+      updated_at: 1.week.ago
+    )
+
+    expect do
+      task.execute
+    end.to change { ActiveRecord::SessionStore::Session.count }.from(2).to(1)
+  end
+end


### PR DESCRIPTION
tackles ticket #129 

We ran into cookie overflow errors where the cookie store exceeded its 4000 kb limit and caused page crashes locally - it was a matter of time before this occurs in production. 

This solution adds the active record session store gem - it relies on a table called sessions which store your session ids. The session ids are then passed back and forth between server and browser. The devise powered cookie will reference the session id and pull data on every request using it as oppose to storing all data inside the cookie store. 

This drastically reduced cookie size from 4000kb+ down to around 50kb. 

There is a sessions cleanup task also added which needs to be run manually every 2 weeks to delete expired or unused sessions. Sessions typically expire after 2 weeks. Deleting a session will log out a User.

Added unit tests and documentation to stabilise functionality and future proof. 