### PR TITLE
#132 rmv console error, made sure functionality works

### DIFF
--- a/app/javascript/controllers/spinner_controller.js
+++ b/app/javascript/controllers/spinner_controller.js
@@ -24,6 +24,5 @@ export default class extends Controller {
   hideSpinner() {
     // console.log("Hide spinner")
     this.spinnerTarget.style.display = "none"
-    this.iframeTarget.style.visibility = "visible"
   }
 }


### PR DESCRIPTION
removes the current browser console error complaining about unreadable styles. 
Removed line of code causing it. 

All other functionality for spinner remains the same and feature works as expected. 