### PR TITLE
#92 set a maximum of 3 resumes per user to save storage space

### DIFF
--- a/app/models/resume.rb
+++ b/app/models/resume.rb
@@ -21,6 +21,8 @@ class Resume < ApplicationRecord
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :job_title, presence: true
 
+  validate :resume_limit, on: :create
+
   def slug_candidates
     [
       %i[first_name last_name job_title]
@@ -33,5 +35,11 @@ class Resume < ApplicationRecord
     # Find the default theme by name or any other identifier
     default_theme = Theme.find_by(name: 'free_default')
     self.theme_id = default_theme.id if default_theme.present?
+  end
+
+  def resume_limit
+    return unless user.present? && user.resumes.count >= 3
+
+    errors.add(:base, 'You can only create a maximum of 3 resumes.')
   end
 end

--- a/app/models/resume.rb
+++ b/app/models/resume.rb
@@ -4,8 +4,8 @@ class Resume < ApplicationRecord
 
   belongs_to :user, counter_cache: :resumes_count
   belongs_to :theme, optional: true
-  has_many :experiences, dependent: :destroy
-  has_many :educations, dependent: :destroy
+  has_many :experiences, -> { order(end_date: :desc) }, dependent: :destroy
+  has_many :educations, -> { order(end_date: :desc) }, dependent: :destroy
   has_many :skills, dependent: :destroy
   has_one :cover_letter, dependent: :destroy
   has_one :social_link, dependent: :destroy

--- a/spec/models/resume_spec.rb
+++ b/spec/models/resume_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe Resume, type: :model do
   describe 'associations' do
     it { should belong_to(:user) }
+    it { should have_many(:experiences).order(end_date: :desc).dependent(:destroy) }
+    it { should have_many(:educations).order(end_date: :desc).dependent(:destroy) }
   end
 
   describe 'validations' do

--- a/spec/models/resume_spec.rb
+++ b/spec/models/resume_spec.rb
@@ -20,5 +20,24 @@ RSpec.describe Resume, type: :model do
       resume = build(:resume, user: nil)
       expect(resume).not_to be_valid
     end
+
+    context 'when the user has reached the resume limit' do
+      let(:user) { create(:user) }
+
+      it 'does not allow the user to create more than 3 resumes' do
+        create_list(:resume, 3, user: user)
+
+        new_resume = build(:resume, user: user)
+        expect(new_resume).not_to be_valid
+        expect(new_resume.errors[:base]).to include('You can only create a maximum of 3 resumes.')
+      end
+
+      it 'allows the user to create up to 3 resumes' do
+        create_list(:resume, 2, user: user)
+
+        third_resume = build(:resume, user: user)
+        expect(third_resume).to be_valid
+      end
+    end
   end
 end

--- a/spec/models/resume_spec.rb
+++ b/spec/models/resume_spec.rb
@@ -42,4 +42,28 @@ RSpec.describe Resume, type: :model do
       end
     end
   end
+
+  describe 'ordering of experiences and educations' do
+    let(:resume) { create(:resume) }
+
+    let!(:experience1) { create(:experience, resume: resume, start_date: 3.years.ago, end_date: 2.years.ago) }
+    let!(:experience2) { create(:experience, resume: resume, start_date: 2.years.ago, end_date: 1.year.ago) }
+    # Currently working status set to true
+    let!(:experience3) do
+      create(:experience, resume: resume, start_date: 1.year.ago, end_date: nil, current_work: true)
+    end
+    let!(:education1) { create(:education, resume: resume, start_date: 3.years.ago, end_date: 3.years.ago) }
+    let!(:education2) { create(:education, resume: resume, start_date: 3.years.ago, end_date: 2.years.ago) }
+    # Currently studying status set to true
+    let!(:education3) do
+      create(:education, resume: resume, start_date: 1.year.ago, end_date: nil, currently_study: true)
+    end
+    it 'orders experiences by end_date in descending order' do
+      expect(resume.experiences).to eq([experience3, experience2, experience1])
+    end
+
+    it 'orders educations by end_date in descending order' do
+      expect(resume.educations).to eq([education3, education2, education1])
+    end
+  end
 end


### PR DESCRIPTION
A user can only have a maximum of 3 resumes created in their accound. 

Added model validation and unit tests to guarantee functionality. 
![Screenshot 2024-08-10 at 11 49 17 AM](https://github.com/user-attachments/assets/1552a8e6-00bb-45c3-9eeb-87875b2a10ea)
