### PR TITLE
Move accordians to forms refactor

### DIFF
--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -37,7 +37,7 @@ class ExperiencesController < ApplicationController
   private
 
   def set_resume
-    @resume = current_user.resumes.friendly.find(params[:resume_id])
+    @resume = current_user.resumes.includes(experiences: :rich_text_content).friendly.find(params[:resume_id])
   end
 
   def set_experience

--- a/app/views/cover_letters/_form.html.haml
+++ b/app/views/cover_letters/_form.html.haml
@@ -1,6 +1,5 @@
 = form_for [@resume, @cover_letter], url: resume_cover_letter_path(@resume) do |f|
   .form-group.mb-3
-    = f.label :content, 'Craft an Executive summary'
     = f.rich_text_area :content, class: 'form-control custom-text-area', placeholder: "- Highlight your career goals and achievments", required: true
 
   = f.submit 'Save Summary', class: 'btn-save'

--- a/app/views/cover_letters/_form.html.haml
+++ b/app/views/cover_letters/_form.html.haml
@@ -2,4 +2,4 @@
   .form-group.mb-3
     = f.rich_text_area :content, class: 'form-control custom-text-area', placeholder: "- Highlight your career goals and achievments", required: true
 
-  = f.submit 'Save Summary', class: 'btn-save'
+  = f.submit 'Save', class: 'btn-save'

--- a/app/views/educations/_form.html.haml
+++ b/app/views/educations/_form.html.haml
@@ -24,7 +24,7 @@
     = f.label :degree, class: 'form-label'
     = f.select :degree, Education.degrees.keys.map { |degree| [degree.titleize, degree] }, {}, class: 'form-select'
 
-  .row.mb-3
+  .row.form-group.mb-3
     .col-md-6
       = f.label :start_date, class: 'form-label'
       = f.date_field :start_date, class: 'form-control'
@@ -32,8 +32,9 @@
       = f.label :end_date, class: 'form-label'
       = f.date_field :end_date, class: 'form-control'
 
-  .form-check.mb-3
-    = f.check_box :currently_study, class: 'form-check-input', id: 'currentStudyCheck'
-    = f.label :currently_study, class: 'form-check-label', for: 'currentStudyCheck', class: 'form-label'
+  .form-group.mb-3
+    .form-check.mb-3
+      = f.check_box :currently_study, class: 'form-check-input', id: 'currentStudyCheck'
+      = f.label :currently_study, class: 'form-check-label', for: 'currentStudyCheck', class: 'form-label'
 
   = f.submit @education.new_record? ? 'Create Education' : 'Update Education', class: 'btn-save'

--- a/app/views/educations/_form.html.haml
+++ b/app/views/educations/_form.html.haml
@@ -37,4 +37,4 @@
       = f.check_box :currently_study, class: 'form-check-input', id: 'currentStudyCheck'
       = f.label :currently_study, class: 'form-check-label', for: 'currentStudyCheck', class: 'form-label'
 
-  = f.submit @education.new_record? ? 'Create Education' : 'Update Education', class: 'btn-save'
+  = f.submit 'Save', class: 'btn-save'

--- a/app/views/educations/edit.html.haml
+++ b/app/views/educations/edit.html.haml
@@ -3,4 +3,5 @@
     .col-lg-3
       = render 'resumes/sidebar'
     .col-lg-6.offset-lg-1
+      = render 'resumes/sections/educations', resume: @resume
       = render 'form', education: @education

--- a/app/views/educations/new.html.haml
+++ b/app/views/educations/new.html.haml
@@ -3,4 +3,5 @@
     .col-lg-3
       = render 'resumes/sidebar'
     .col-lg-6.offset-lg-1
+      = render 'resumes/sections/educations', resume: @resume
       = render 'form', education: @education

--- a/app/views/experiences/_form.html.haml
+++ b/app/views/experiences/_form.html.haml
@@ -48,4 +48,4 @@
         = f.check_box :remote_work, class: 'form-check-input', id: 'remoteWorkCheck'
         = f.label :remote_work, class: 'form-check-label', for: 'remoteWorkCheck'
 
-  = f.submit experience.new_record? ? 'Next' : 'Update Experience', class: 'btn-save'
+  = f.submit 'Save', class: 'btn-save'

--- a/app/views/experiences/edit.html.haml
+++ b/app/views/experiences/edit.html.haml
@@ -3,4 +3,5 @@
     .col-lg-3
       = render 'resumes/sidebar'
     .col-lg-6.offset-lg-1
+      = render 'resumes/sections/experiences', resume: @resume
       = render 'form', experience: @experience

--- a/app/views/experiences/new.html.haml
+++ b/app/views/experiences/new.html.haml
@@ -3,4 +3,5 @@
     .col-lg-3
       = render 'resumes/sidebar'
     .col-lg-6.offset-lg-1
+      = render 'resumes/sections/experiences', resume: @resume
       = render 'form', experience: @experience

--- a/app/views/home/about.html.haml
+++ b/app/views/home/about.html.haml
@@ -36,7 +36,7 @@
       .col-md-3.pt-4
         .card.card-orange-blue
           %h5.text-center Yushus Komarlu
-          %h6.text-center Founding Software Engineer
+          %h6.text-center Software Engineer
           .mb-5.d-flex.justify-content-center.align-content-start
             .rounded-circle.bg-white{style:"width: 6rem;height: 6rem;"}
               %img{src: "https://logo-career-crafter-pro.s3.amazonaws.com/logo.png", alt: "Career Crafter Pro Logo", style: "height: 95px;"}
@@ -52,7 +52,7 @@
       .col-md-3.pt-4
         .card.card-orange-blue
           %h5.text-center Daniel Laij
-          %h6.text-center Founding Software Engineer
+          %h6.text-center Software Engineer
           .mb-5.d-flex.justify-content-center.align-congent-start
             .rounded-circle.bg-white{style:"width: 6rem;height: 6rem;"}
               %img{src: "https://logo-career-crafter-pro.s3.amazonaws.com/logo.png", alt: "Career Crafter Pro Logo", style: "height: 95px;"}
@@ -65,4 +65,3 @@
               %a{ href: "https://www.linkedin.com/in/daniellaij", target: "_blank", style: "text-decoration: none; color: white" }
                 %i.bi.bi-linkedin
                 LinkedIn
-          

--- a/app/views/layouts/resumes/free_default_components/_index.haml
+++ b/app/views/layouts/resumes/free_default_components/_index.haml
@@ -50,7 +50,8 @@
               .experience-item
                 %h4= "#{experience.job_title} at #{experience.company_name}"
                 .date-footer
-                  %span= "#{experience.start_date.strftime('%b %Y')} - #{experience.current_work ? 'Present' : experience.end_date.strftime('%b %Y')}"
+                  - if experience.end_date.present? || experience.current_work
+                    %span= "#{experience.start_date.strftime('%b %Y')} - #{experience.current_work ? 'Present' : experience.end_date.strftime('%b %Y')}"
                   - if experience.city.present? || experience.province.present? || experience.country.present?
                     #{","}
                     - location_parts = []

--- a/app/views/layouts/resumes/free_modern_components/_index.haml
+++ b/app/views/layouts/resumes/free_modern_components/_index.haml
@@ -23,7 +23,8 @@
         .experience-item
           %h4= "#{experience.job_title} at #{experience.company_name}"
           .date-footer
-            %span= "#{experience.start_date.strftime('%b %Y')} - #{experience.current_work ? 'Present' : experience.end_date.strftime('%b %Y')}"
+            - if experience.end_date.present? || experience.current_work
+              %span= "#{experience.start_date.strftime('%b %Y')} - #{experience.current_work ? 'Present' : experience.end_date.strftime('%b %Y')}"
             - if experience.city.present? || experience.province.present? || experience.country.present?
               #{","}
               - location_parts = []

--- a/app/views/layouts/resumes/premium_classic_components/_index.haml
+++ b/app/views/layouts/resumes/premium_classic_components/_index.haml
@@ -25,7 +25,8 @@
                     %h4= "#{experience.job_title} at #{experience.company_name}"
                     %p= raw experience.content
                     .date-footer
-                      %span= "#{experience.start_date.strftime('%b %Y')} - #{experience.current_work ? 'Present' : experience.end_date.strftime('%b %Y')}"
+                      - if experience.end_date.present? || experience.current_work
+                        %span= "#{experience.start_date.strftime('%b %Y')} - #{experience.current_work ? 'Present' : experience.end_date.strftime('%b %Y')}"
                       - if experience.city.present? || experience.province.present? || experience.country.present?
                         #{","}
                         - location_parts = []

--- a/app/views/resumes/sections/_educations.html.haml
+++ b/app/views/resumes/sections/_educations.html.haml
@@ -1,43 +1,52 @@
-- @resume.educations.each do |education|
-  .card.mb-3
-    .card-body.hoverable-card-body
-      .d-flex.flex-column.flex-md-row.justify-content-between.align-items-center.mb-2
-        %h2.h5= education.institution_name
-        .btn-group.mt-3.mt-md-0
-          = link_to edit_resume_education_path(@resume, education), class: 'btn btn-outline-primary btn-sm me-2' do
-            = image_tag('pencil.png', alt: 'Edit', width: "20")
-          = form_for([@resume, education], method: :delete, data: { confirm: 'Are you sure?' }) do
-            = button_tag(type: 'submit', class: 'btn btn-outline-danger btn-sm') do
-              = image_tag('trashcan.png', alt: 'Delete', width: "20")
-      %h6.card-subtitle.mb-2.text-muted= education.location
-      %p
-        %i.bi.bi-journal-bookmark-fill.me-2
-        = education.field_of_study
-      .row
-        .col-12.col-md-6
-          %p
-            %i.bi.bi-mortarboard-fill.me-2
-            %strong Degree:
-            = education.degree
-          %p
-            %i.bi.bi-map-fill.me-2
-            %strong Province:
-            = education.location
-        .card-footer
-          .row.text-muted
-            .col-auto
-              %i.bi.bi-calendar2-event-fill
-              %span.ms-2
-                %strong Start:
-                = education.start_date.strftime('%B %d, %Y')
-            - if education.end_date.present?
-              .col-auto
-                %i.bi.bi-calendar2-x-fill
-                %span.ms-2
-                  %strong End:
-                  = education.end_date.strftime('%B %d, %Y')
-            - if education.currently_study
-              .col-auto
-                %i.bi.bi-check2-circle
-                %span.ms-2
-                  %strong Currently Studying
+- if @resume.educations.exists?
+  .accordion#educationAccordion.p-4.m-4
+    - @resume.educations.each_with_index do |education, index|
+      - if education.id.present?
+        .accordion-item.mb-3
+          .accordion-header
+            %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseEducation#{index}" }, aria_expanded: "false", aria_controls: "collapseEducation#{index}" }
+              = education.institution_name
+          .accordion-collapse.collapse{id: "collapseEducation#{index}", aria_labelledby: "headingEducation#{index}", data: { bs_parent: "#educationAccordion" } }
+            .accordion-body.bg-dark.text-white
+              .card-body.hoverable-card-body
+                .d-flex.flex-column.flex-md-row.justify-content-between.align-items-center.mb-2
+                  %h2.h5= education.institution_name
+                  .btn-group.mt-3.mt-md-0
+                    = link_to edit_resume_education_path(@resume, education), class: 'btn btn-outline-primary btn-sm me-2' do
+                      = image_tag('pencil.png', alt: 'Edit', width: "20")
+                    = form_for([@resume, education], method: :delete, data: { confirm: 'Are you sure?' }) do
+                      = button_tag(type: 'submit', class: 'btn btn-outline-danger btn-sm') do
+                        = image_tag('trashcan.png', alt: 'Delete', width: "20")
+                %h6.card-subtitle.mb-2.text-muted= education.location
+                %p
+                  %i.bi.bi-journal-bookmark-fill.me-2
+                  = education.field_of_study
+                .row
+                  .col-12.col-md-6
+                    %p
+                      %i.bi.bi-mortarboard-fill.me-2
+                      %strong Degree:
+                      = education.degree
+                    %p
+                      %i.bi.bi-map-fill.me-2
+                      %strong Province:
+                      = education.location
+
+                .card-footer
+                  .row.text-muted
+                    .col-auto
+                      %i.bi.bi-calendar2-event-fill
+                      %span.ms-2
+                        %strong Start:
+                        = education.start_date.strftime('%B %d, %Y')
+                    - if education.end_date.present?
+                      .col-auto
+                        %i.bi.bi-calendar2-x-fill
+                        %span.ms-2
+                          %strong End:
+                          = education.end_date.strftime('%B %d, %Y')
+                    - if education.currently_study
+                      .col-auto
+                        %i.bi.bi-check2-circle
+                        %span.ms-2
+                          %strong Currently Studying

--- a/app/views/resumes/sections/_experiences.html.haml
+++ b/app/views/resumes/sections/_experiences.html.haml
@@ -1,47 +1,52 @@
-- @resume.experiences.each do |experience|
-  .card.mb-3
-    .card-body.hoverable-card-body
-      .d-flex.flex-column.flex-md-row.justify-content-between.align-items-center.mb-2
-        %h2.h5
-          = experience.job_title
-          %span at
-          = experience.company_name
-        .btn-group.mt-3.mt-md-0
-          = link_to edit_resume_experience_path(@resume, experience), class: 'btn btn-outline-primary btn-sm me-2' do
-            = image_tag('pencil.png', alt: 'Edit', width: "20")
-          = form_for([@resume, experience], method: :delete, data: { confirm: 'Are you sure?' }) do
-            = button_tag(type: 'submit', class: 'btn btn-outline-danger btn-sm') do
-              = image_tag('trashcan.png', alt: 'Delete', width: "20")
-      %h6.card-subtitle.mb-2.text-muted= experience.job_title
-      .row
-        .col-6.col-md-6
-          %p= experience.content
-          - if experience.remote_work
-            %p
-              %i.bi.bi-broadcast-pin.me-2
-              %strong Remote Work
-          %p
-            %i.bi.bi-map-fill.me-2
-            %strong Address:
-            = experience.country
-            = experience.province
-            = experience.city
+- if @resume.experiences.exists?
+  .accordion#experienceAccordion.p-4.m-4
+    - @resume.experiences.each_with_index do |experience, index|
+      - if experience.id.present?
+        .accordion-item.mb-3
+          .accordion-header
+            %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseExperience#{index}" }, aria_expanded: "false", aria_controls: "collapseExperience#{index}" }
+              = "#{experience.job_title} at #{experience.company_name}"
+          .accordion-collapse.collapse{id: "collapseExperience#{index}", aria_labelledby: "headingExperience#{index}", data: { bs_parent: "#experienceAccordion" } }
+            .accordion-body.bg-dark.text-white
+              .card-body.hoverable-card-body
+                .d-flex.flex-column.flex-md-row.justify-content-between.align-items-center.mb-2
+                  %h2.h5
+                    = experience.job_title
+                    %span at
+                    = experience.company_name
+                  .btn-group.mt-3.mt-md-0
+                    = link_to edit_resume_experience_path(@resume, experience), class: 'btn btn-outline-primary btn-sm me-2' do
+                      = image_tag('pencil.png', alt: 'Edit', width: "20")
+                    = form_for([@resume, experience], method: :delete, data: { confirm: 'Are you sure?' }) do
+                      = button_tag(type: 'submit', class: 'btn btn-outline-danger btn-sm') do
+                        = image_tag('trashcan.png', alt: 'Delete', width: "20")
+                .row
+                  .col-6.col-md-6
+                    %p= experience.content
+                    - if experience.remote_work
+                      %p
+                        %i.bi.bi-broadcast-pin.me-2
+                        %strong Remote Work
+                    %em
+                      = experience.city.present? ? "#{experience.city}, " : ""
+                      = experience.province.present? ? "#{experience.province}, " : ""
+                      = experience.country.present? ? experience.country : ""
 
-          .card-footer
-            .row.text-muted
-              .col-auto
-                %i.bi.bi-calendar2-event-fill
-                %span.ms-2
-                  %strong Start:
-                  = experience.start_date.strftime('%B %d, %Y')
-              - if experience.end_date.present?
-                .col-auto
-                  %i.bi.bi-calendar2-x-fill
-                  %span.ms-2
-                    %strong End:
-                    = experience.end_date.strftime('%B %d, %Y')
-              - if experience.remote_work
-                .col-auto
-                  %i.bi.bi-check2-circle
-                  %span.ms-2
-                    %strong Currently working here
+                .card-footer
+                  .row.text-muted
+                    .col-auto
+                      %i.bi.bi-calendar2-event-fill
+                      %span.ms-2
+                        %strong Start:
+                        = experience.start_date.strftime('%B %d, %Y')
+                    - if experience.end_date.present?
+                      .col-auto
+                        %i.bi.bi-calendar2-x-fill
+                        %span.ms-2
+                          %strong End:
+                          = experience.end_date.strftime('%B %d, %Y')
+                    - if experience.current_work
+                      .col-auto
+                        %i.bi.bi-check2-circle
+                        %span.ms-2
+                          %strong Currently working here

--- a/app/views/resumes/show.html.haml
+++ b/app/views/resumes/show.html.haml
@@ -16,51 +16,6 @@
               Download PDF
 
       .container.pt-4
-        .accordion#resumeAccordion
-          .accordion-item
-            .accordion-header
-              %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapsePersonalDetails" }, aria_expanded: "true", aria_controls: "collapsePersonalDetails" }
-                Edit Personal Details
-            .accordion-collapse.collapse#collapsePersonalDetails{ aria_labelledby: "headingPersonalDetails", data: { bs_parent: "#resumeAccordion" } }
-              .accordion-body.bg-dark.text-white
-                = render 'resumes/sections/personal_details', resume: @resume
-
-          - if @resume.educations.any?
-            .accordion-item
-              .accordion-header
-                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseEducation" }, aria_expanded: "true", aria_controls: "collapseEducation" }
-                  Edit Education
-              .accordion-collapse.collapse#collapseEducation{ aria_labelledby: "headingEducation", data: { bs_parent: "#resumeAccordion" } }
-                .accordion-body.bg-dark.text-white
-                  = render 'resumes/sections/educations', resume: @resume
-
-          - if @resume.skills.any?
-            .accordion-item
-              .accordion-header
-                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseSkills" }, aria_expanded: "true", aria_controls: "collapseSkills" }
-                  Edit Skills
-              .accordion-collapse.collapse#collapseSkills{ aria_labelledby: "headingSkills", data: { bs_parent: "#resumeAccordion" } }
-                .accordion-body.bg-dark.text-white
-                  = render 'resumes/sections/skills', resume: @resume
-
-          - if @resume.social_link.present?
-            .accordion-item
-              .accordion-header
-                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseSocialLinks" }, aria_expanded: "true", aria_controls: "collapseSocialLinks" }
-                  Edit Social Links
-              .accordion-collapse.collapse#collapseSocialLinks{ aria_labelledby: "headingSocialLinks", data: { bs_parent: "#resumeAccordion" } }
-                .accordion-body.bg-dark.text-white
-                  = render 'resumes/sections/social_links', resume: @resume
-
-          - if @resume.cover_letter.present?
-            .accordion-item
-              .accordion-header
-                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseCoverLetter" }, aria_expanded: "true", aria_controls: "collapseCoverLetter" }
-                  Edit Summary
-              .accordion-collapse.collapse#collapseCoverLetter{ aria_labelledby: "headingCoverLetter", data: { bs_parent: "#resumeAccordion" } }
-                .accordion-body.bg-dark.text-white
-                  = render 'resumes/sections/cover_letter', resume: @resume
-
         .d-none.d-md-block
           %h3.pt-4 PDF Preview
           - if @resume.theme

--- a/app/views/resumes/show.html.haml
+++ b/app/views/resumes/show.html.haml
@@ -25,15 +25,6 @@
               .accordion-body.bg-dark.text-white
                 = render 'resumes/sections/personal_details', resume: @resume
 
-          - if @resume.experiences.any?
-            .accordion-item
-              .accordion-header
-                %button.accordion-button.collapsed.bg-secondary.text-white{ type: "button", data: { bs_toggle: "collapse", bs_target: "#collapseWorkExperience" }, aria_expanded: "true", aria_controls: "collapseWorkExperience" }
-                  Edit Work Experience
-              .accordion-collapse.collapse#collapseWorkExperience{ aria_labelledby: "headingWorkExperience", data: { bs_parent: "#resumeAccordion" } }
-                .accordion-body.bg-dark.text-white
-                  = render 'resumes/sections/experiences', resume: @resume
-
           - if @resume.educations.any?
             .accordion-item
               .accordion-header

--- a/app/views/social_links/_form.html.haml
+++ b/app/views/social_links/_form.html.haml
@@ -34,4 +34,4 @@
     = f.label :personal_website_url, 'Personal Website URL'
     = f.text_field :personal_website_url, class: 'form-control', placeholder: 'https://www.yourwebsite.com'
 
-  = f.submit 'Save Social Links', class: 'btn-save'
+  = f.submit 'Save', class: 'btn-save'


### PR DESCRIPTION
Removed accordian. Added accordian view to experience and education form selections. Users can now rely exclusively on the user sidebar to guide their experience. 

Made some other mindor updates also. 

New user resume dashboard layout without accordian

![Screenshot 2024-08-20 at 5 19 18 PM](https://github.com/user-attachments/assets/3d732cbe-75de-40f6-a726-1c8307ed1172)

New form view for education and experience new and edit form pages: 

![Screenshot 2024-08-20 at 5 19 45 PM](https://github.com/user-attachments/assets/59a8aa66-4950-48ca-8f83-ff876804f147)
