### PR TITLE
Dashboard iframe resume

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -178,3 +178,10 @@ a {
   opacity: 1; /* Full visibility on hover */
   color: #f6f2f2; /* Change color on hover for visibility */
 }
+
+/* IFrame spinner */
+.spinner-border {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+}

--- a/app/assets/stylesheets/theme_previews.css
+++ b/app/assets/stylesheets/theme_previews.css
@@ -35,6 +35,43 @@ input[type='radio']:checked + label .theme-content {
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
 }
 
+/* IFrame spinner */
+.spinner-border {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+}
+
+.iframe-wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+/* styling IFrame as link with hover effect */
+.overlay-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 10;
+  background-color: rgba(0, 0, 0, 0);
+  cursor: pointer;
+  text-decoration: none;
+  outline: none;
+}
+
+.overlay-link:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+  opacity: 0.5;
+}
+
+.overlay-link:active {
+  background-color: rgba(0, 0, 0, 0.2);
+  opacity: 0.7;
+}
+
 @media (max-width: 800px) {
   .theme-content {
     min-height: 400px;  /* Slightly less tall for smaller devices */

--- a/app/views/home/dashboard.html.haml
+++ b/app/views/home/dashboard.html.haml
@@ -18,16 +18,18 @@
               %small.text-muted.text-end.text-white
                 last updated #{resume.updated_at.strftime("%B %d, %Y")}
               .d-none.d-md-block
-                .spinner-container.d-flex.justify-content-center.align-items-center
-                  .spinner-border.text-danger.spinner-border-lg{ role: "status", data: { controller: "spinner", spinner_target: "spinner" } }
-                    %span.visually-hidden Loading...
-                %iframe{src: "#{resume_path(resume, format: :pdf)}#toolbar=0", width: "100%", height: "750px", frameborder: "0", data: { spinner_target: "iframe" }}
+                .iframe-wrapper.position-relative
+
+                  .spinner-container.d-flex.justify-content-center.align-items-center
+                    .spinner-border.text-danger.spinner-border-lg{ role: "status", data: { controller: "spinner", spinner_target: "spinner" } }
+                      %span.visually-hidden Loading...
+                  %iframe{src: "#{resume_path(resume, format: :pdf)}#toolbar=0", width: "100%", height: "750px", frameborder: "0", data: { spinner_target: "iframe" }}
+                  %a.overlay-link{href: resume_path(resume)}
 
               .col-md-4.d-block.d-md-none
                 .theme-content
                   - @resume = resume
                   = render "layouts/resumes/#{resume.theme.name}_components/index", resume: resume
-
 
               .card-footer
                 .btn-group

--- a/app/views/home/dashboard.html.haml
+++ b/app/views/home/dashboard.html.haml
@@ -17,16 +17,17 @@
             .col
               %small.text-muted.text-end.text-white
                 last updated #{resume.updated_at.strftime("%B %d, %Y")}
-              .theme-content.bg-light.p-4.rounded-3.d-none.d-md-block
-                - @resume = resume
-                = render "layouts/resumes/#{resume.theme.name}_components/index", resume: resume
+              .d-none.d-md-block
+                .spinner-container.d-flex.justify-content-center.align-items-center
+                  .spinner-border.text-danger.spinner-border-lg{ role: "status", data: { controller: "spinner", spinner_target: "spinner" } }
+                    %span.visually-hidden Loading...
+                %iframe{src: "#{resume_path(resume, format: :pdf)}#toolbar=0", width: "100%", height: "750px", frameborder: "0", data: { spinner_target: "iframe" }}
+
               .col-md-4.d-block.d-md-none
-                %h5.card-title= resume.first_name
-                %p.card-text= resume.job_title
-                %p.card-text= "#{resume.country}, #{resume.state}"
-                %p.card-text= resume.phone_number
-                %p.card-text= resume.email
-                = render 'resumes/completion_pie_chart', resume: resume
+                .theme-content
+                  - @resume = resume
+                  = render "layouts/resumes/#{resume.theme.name}_components/index", resume: resume
+
 
               .card-footer
                 .btn-group


### PR DESCRIPTION
Adds resume in iframe format for the user page/dashboard. Removed iframe border and added a hover over effect with option to click into the iframe and be navigated to the resume show page (for each iframe/resume, up to 3).
ticket #151 

![Screenshot 2024-08-24 at 3 48 53 PM](https://github.com/user-attachments/assets/f2db6730-9771-4007-a42e-c7ad2b487e12)

Hover effect on iframe

![Screenshot 2024-08-24 at 4 09 47 PM](https://github.com/user-attachments/assets/b7987691-df36-4f81-9acf-4db7c6350dff)
