### PR TITLE
fixed nil error which was causing page crash on user dashboard for te…

### DIFF
--- a/app/views/layouts/resumes/free_default_components/_index.haml
+++ b/app/views/layouts/resumes/free_default_components/_index.haml
@@ -64,7 +64,6 @@
 
         - if @resume.social_link.present?
           %section
-            %h3 Social Links
             %ul.social-links
               - %w(linkedin_url github_url twitter_url youtube_url facebook_url instagram_url personal_website_url).each do |link|
                 - if @resume.social_link[link].present?

--- a/app/views/layouts/resumes/free_default_components/_index.haml
+++ b/app/views/layouts/resumes/free_default_components/_index.haml
@@ -62,7 +62,7 @@
                     = location_parts.join(', ')
                 = raw experience.content
 
-        - if @resume.social_link.nil?
+        - if @resume.social_link.present?
           %section
             %h3 Social Links
             %ul.social-links

--- a/app/views/layouts/resumes/free_modern_components/_index.haml
+++ b/app/views/layouts/resumes/free_modern_components/_index.haml
@@ -56,7 +56,6 @@
 
   - if @resume.social_link.present?
     %section
-      %h3 Social Links
       %ul.social-links
         - %w(linkedin_url github_url twitter_url youtube_url facebook_url instagram_url personal_website_url).each do |link|
           - if @resume.social_link[link].present?

--- a/app/views/layouts/resumes/free_modern_components/_index.haml
+++ b/app/views/layouts/resumes/free_modern_components/_index.haml
@@ -54,7 +54,7 @@
           %span
             = skill.name
 
-  - if @resume.social_link.nil?
+  - if @resume.social_link.present?
     %section
       %h3 Social Links
       %ul.social-links

--- a/app/views/layouts/resumes/premium_classic_components/_index.haml
+++ b/app/views/layouts/resumes/premium_classic_components/_index.haml
@@ -55,7 +55,7 @@
                   - @resume.skills.each do |skill|
                     %li.skill-badge= skill.name
 
-            - if @resume.social_link.nil?
+            - if @resume.social_link.present?
               .section
                 %h3 Social Links
                 %ul.social-links

--- a/app/views/layouts/resumes/premium_classic_components/_index.haml
+++ b/app/views/layouts/resumes/premium_classic_components/_index.haml
@@ -57,7 +57,6 @@
 
             - if @resume.social_link.present?
               .section
-                %h3 Social Links
                 %ul.social-links
                   - %w(linkedin_url github_url twitter_url youtube_url facebook_url instagram_url personal_website_url).each do |link|
                     - if @resume.social_link[link].present?


### PR DESCRIPTION
There was a page crash during beta testing - users complained that after creating a resume, they were seeing the error page. This happens because the previous commit added a line to check if social links existed with the .nil? check - if they didn't the intent was to hide that section. Instead whena user has no social links, it failed and crashed page instead. 

Root cause: 

-> Templates were updated